### PR TITLE
failed to send buffer of zlib output compression 

### DIFF
--- a/src/Http/boot.php
+++ b/src/Http/boot.php
@@ -21,7 +21,7 @@ mb_http_output('UTF-8');
 mb_http_input('UTF-8');
 mb_language('uni');
 mb_regex_encoding('UTF-8');
-ob_start('mb_output_handler');
+// ob_start('mb_output_handler');
 date_default_timezone_set('Europe/Rome');
 setlocale(LC_CTYPE, 'en_US'); //correct transliteration
 


### PR DESCRIPTION
Disable `ob_start('mb_output_handler');` in src/Http/boot.php

Fix Error in laravel 5.8 when zlib.output_compression = On
